### PR TITLE
Only clear alarms if setting is disabled.

### DIFF
--- a/state/src/commonMain/kotlin/com/inkapplications/sleeps/state/alarms/AlarmScheduler.kt
+++ b/state/src/commonMain/kotlin/com/inkapplications/sleeps/state/alarms/AlarmScheduler.kt
@@ -49,18 +49,20 @@ internal class AlarmScheduler(
 
     private fun scheduleAlarm(alarmParameters: AlarmParameters) {
         logger.trace("Removing all alarms")
-        alarmAccess.removeAlarm(wakeAlarm)
-        alarmAccess.removeAlarm(sleepAlarm)
 
         if (alarmParameters.settings.wakeAlarm) {
             logger.trace("Scheduling Wake alarm for ${alarmParameters.schedule.wake}")
             alarmAccess.addAlarm(wakeAlarm, alarmParameters.schedule.wake.instant)
         } else {
             logger.trace("Wake alarm disabled")
+            alarmAccess.removeAlarm(wakeAlarm)
         }
 
         when {
-            !alarmParameters.settings.sleepNotifications -> logger.trace("Sleep alarm disabled")
+            !alarmParameters.settings.sleepNotifications -> {
+                logger.trace("Sleep alarm disabled")
+                alarmAccess.removeAlarm(sleepAlarm)
+            }
             clock.now() > alarmParameters.schedule.sleep.instant -> logger.trace("Sleep alarm time has passed")
             else -> alarmAccess.addAlarm(sleepAlarm, alarmParameters.schedule.sleep.instant)
         }

--- a/state/src/commonTest/kotlin/com/inkapplications/sleeps/state/alarms/AlarmSchedulerTest.kt
+++ b/state/src/commonTest/kotlin/com/inkapplications/sleeps/state/alarms/AlarmSchedulerTest.kt
@@ -61,9 +61,7 @@ class AlarmSchedulerTest {
         fakeScheduleAccess.schedule.emit(fakeSchedule)
         runCurrent()
 
-        assertEquals(2, alarmAccess.clearCalls.size, "Should clear existing alarms")
-        assertNotNull(alarmAccess.clearCalls.find { it.value == "wake" }, " Wake alarm should be cleared")
-        assertNotNull(alarmAccess.clearCalls.find { it.value == "sleep" }, " Sleep alarm should be cleared")
+        assertEquals(0, alarmAccess.clearCalls.size, "Should not clear alarms")
         assertEquals(2, alarmAccess.addCalls.size)
 
         val wakeAlarm = alarmAccess.addCalls.find { it.first.value == "wake" }?.second
@@ -111,6 +109,8 @@ class AlarmSchedulerTest {
         runCurrent()
 
         assertEquals(2, alarmAccess.clearCalls.size, "Should clear existing alarms when disabled")
+        assertNotNull(alarmAccess.clearCalls.find { it.value == "wake" }, " Wake alarm should be cleared")
+        assertNotNull(alarmAccess.clearCalls.find { it.value == "sleep" }, " Sleep alarm should be cleared")
         assertEquals(0, alarmAccess.addCalls.size, "Should not set any alarms when disabled")
 
         job.cancel()


### PR DESCRIPTION
This is relying on Android's intent system to prevent duplicate alarms